### PR TITLE
Fixes some test failures

### DIFF
--- a/src/hundred_pushups/datetime.cljc
+++ b/src/hundred_pushups/datetime.cljc
@@ -31,10 +31,6 @@
   [second-since-epoch]
   (time.coerce/to-date second-since-epoch))
 
-(comment
-  (dt/inst (time/today-at 0 00))
-  )
-
 (defn ct-fmt->moment-fmt
   "Converts a cljs-time format string to a moment.js format str
    See http://momentjs.com/docs/#/parsing/string-format/ for details."

--- a/src/hundred_pushups/datetime.cljc
+++ b/src/hundred_pushups/datetime.cljc
@@ -31,6 +31,10 @@
   [second-since-epoch]
   (time.coerce/to-date second-since-epoch))
 
+(comment
+  (dt/inst (time/today-at 0 00))
+  )
+
 (defn ct-fmt->moment-fmt
   "Converts a cljs-time format string to a moment.js format str
    See http://momentjs.com/docs/#/parsing/string-format/ for details."
@@ -104,5 +108,3 @@
      [(time/year local-dt)
       (time/month local-dt)
       (time/day local-dt)])))
-
-

--- a/test/hundred_pushups/core_test.cljc
+++ b/test/hundred_pushups/core_test.cljc
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer [testing use-fixtures is deftest]]
             [clojure.spec :as s]
             [clojure.test.check.generators :as gen]
-            [clj-time.core :as time]
+            #?@(:clj  [[clj-time.core :as time]
+                       ]
+                :cljs [[cljs-time.core :as time]])
             [hundred-pushups.test-helper :refer [instrument-all check-asserts] :include-macros true]
             [hundred-pushups.core :refer [day->log suggested-day analyze-history dummy-ts last-days-log completed-circuit? parse-int merge-day-changes format-whitelist-row valid-hour-time todays-range next-workout-time]]
             [hundred-pushups.datetime :as dt]

--- a/test/hundred_pushups/datetime_test.cljc
+++ b/test/hundred_pushups/datetime_test.cljc
@@ -1,7 +1,9 @@
 (ns hundred-pushups.datetime-test
   (:require [clojure.test :refer [testing deftest is]]
             [clojure.spec :as s]
-            [clj-time.core :as time]
+            #?@(:clj  [[clj-time.core :as time]
+                       ]
+                :cljs [[cljs-time.core :as time]])
             [hundred-pushups.datetime :refer [inst ct-fmt->moment-fmt now inst->str local-date parse-time]]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]))
 
@@ -22,10 +24,10 @@
 
 
 (deftest parse-time-test
-  (is (= (time/today-at 0 00), (parse-time "12am")))
-  (is (= (time/today-at 9 00), (parse-time "9am")))
-  (is (= (time/today-at 15 00), (parse-time  "3pm")))
-  (is (= (time/today-at 23 00), (parse-time  "11pm"))))
+  (is (= (inst (time/today-at 0 00)), (inst (parse-time "12am"))))
+  (is (= (inst (time/today-at 9 00)), (inst (parse-time "9am"))))
+  (is (= (inst (time/today-at 15 00)), (inst (parse-time  "3pm"))))
+  (is (= (inst (time/today-at 23 00)), (inst (parse-time  "11pm")))))
 
 ;; FIXME - you can't set time zones in CLJS
 ;; https://github.com/andrewmcveigh/cljs-time/issues/14


### PR DESCRIPTION
I did a PR for your PR!

Sorry, I'm messing around with CLJS tests because I wasn't happy
with how the CLJ tests would pass and then the real app would break.
But I'm not yet sure the CLJS tests are fast or reliable enough to
really detect failures, so I still have the CLJ tests for now, which
makes it doubly annoying to get tests to pass with all the double-library
weirdness. I need to just yank out the CLJ tests at some point.